### PR TITLE
Send test failure notifications

### DIFF
--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -68,6 +68,7 @@ jobs:
   # on the test results.
   notifications:
     needs: python-unit-tests
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Notify on test results

--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -72,24 +72,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify on test results
-      if: needs.python-unit-tests.result == 'failure'
-      uses: dawidd6/action-send-mail@v3
-      with:
-        server_address: smtp.gmail.com
-        server_port: 587
-        username: ${{ secrets.NOTIFICATION_MAIL_USERNAME }}
-        password: ${{ secrets.NOTIFICATION_MAIL_PASSWORD }}
-        
-        subject: "❌ CI Alert: Test Failure in ${{ github.repository }}"
-        body: |
-          The Python unit tests failed!
+        if: needs.python-unit-tests.result == 'failure'
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.NOTIFICATION_MAIL_USERNAME }}
+          password: ${{ secrets.NOTIFICATION_MAIL_PASSWORD }}
           
-          Repository: ${{ github.repository }}
-          Branch: ${{ github.ref_name }}
-          Commit: ${{ github.sha }}
-          
-          View Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        
-        # Parameterized Recipient
-        to: ${{ secrets.NOTIFICATION_EMAIL }}
-        from: GitHub Actions Bot
+          subject: "❌ CI Alert: Test Failure in ${{ github.repository }}"
+          body: |
+            The Python unit tests failed!
+            
+            Repository: ${{ github.repository }}
+            Branch: ${{ github.ref_name }}
+            Commit: ${{ github.sha }}
+            
+            View Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          to: ${{ secrets.NOTIFICATION_EMAIL }}
+          from: GitHub Actions Bot

--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -72,9 +72,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify on test results
-        run: |
-          if [ "${{ needs.python-unit-tests.result }}" == "success" ]; then
-            echo "success notifications go here"
-          else
-            echo "failure notifications go here"
-          fi
+      if: needs.python-unit-tests.result == 'failure'
+      uses: dawidd6/action-send-mail@v3
+      with:
+        server_address: smtp.gmail.com
+        server_port: 587
+        username: ${{ secrets.NOTIFICATION_MAIL_USERNAME }}
+        password: ${{ secrets.NOTIFICATION_MAIL_PASSWORD }}
+        
+        subject: "❌ CI Alert: Test Failure in ${{ github.repository }}"
+        body: |
+          The Python unit tests failed!
+          
+          Repository: ${{ github.repository }}
+          Branch: ${{ github.ref_name }}
+          Commit: ${{ github.sha }}
+          
+          View Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        
+        # Parameterized Recipient
+        to: ${{ secrets.NOTIFICATION_EMAIL }}
+        from: GitHub Actions Bot

--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -75,9 +75,9 @@ jobs:
         if: needs.python-unit-tests.result == 'failure'
         uses: dawidd6/action-send-mail@v3
         with:
-          server_address: smtp.gmail.com
-          server_port: 587
-          username: ${{ secrets.NOTIFICATION_MAIL_USERNAME }}
+          server_address: ${{vars.NOTIFICATION_MAIL_SERVER_ADDRESS}}
+          server_port: $${{vars.NOTIFICATION_MAIL_PORT}}
+          username: ${{ vars.NOTIFICATION_MAIL_USERNAME }}
           password: ${{ secrets.NOTIFICATION_MAIL_PASSWORD }}
           
           subject: "❌ CI Alert: Test Failure in ${{ github.repository }}"
@@ -90,5 +90,5 @@ jobs:
             
             View Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-          to: ${{ secrets.NOTIFICATION_EMAIL }}
+          to: ${{ vars.NOTIFICATION_TO_EMAIL }}
           from: GitHub Actions Bot


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## Resolves

Implements automated email alerts for failed CI pipeline runs.

## Changes

Modified the GitHub Actions workflow to ensure build failures are reported to the team immediately:
- **Workflow Reliability**: Added if: always() to the notifications job to prevent it from being skipped when the testing job fails.
- **SMTP Integration**: Replaced placeholder echo statements with the dawidd6/action-send-mail@v3 action for formal email delivery.
- **Contextual Notifications**: Configured the email body to dynamically include the repository name, branch name, commit SHA, and a direct link to the failed logs for faster debugging.
- **Security & Variables**: Added server and recipient configurations to GitHub Variables and used Secrets for the SMTP password to maintain security best practices.

## Testing

- **Simulated Failure**: Triggered the workflow with a failing test case to verify the notifications job executes as expected.
- **Metadata Accuracy**: Confirmed the email body correctly renders ${{ github.ref_name }} and ${{ github.run_id }} for precise log linking.
- **Conditional Check**: Verified that emails are only dispatched when the python-unit-tests job result is specifically 'failure'.

## Screenshots
Email Notification Screenshot
<img width="931" height="271" alt="image" src="https://github.com/user-attachments/assets/4bce4721-d7f6-4eed-9ac1-d42c2744d702" />


## Dependencies

- dawidd6/action-send-mail@v3
-  Repository variables:
   - NOTIFICATION_MAIL_PORT
   - NOTIFICATION_MAIL_SERVER_ADDRESS
   - NOTIFICATION_MAIL_USERNAME
   - NOTIFICATION_TO_EMAIL
- Repository secrets:
   - NOTIFICATION_MAIL_PASSWORD



## Breaking Changes

**None**. This update adds a secondary notification job and does not modify the existing test environment or application code.