### PR TITLE
feat: add email notifications on job failure

### DIFF
--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -69,11 +69,28 @@ jobs:
   notifications:
     needs: python-unit-tests
     runs-on: ubuntu-latest
+    if: always()
     steps:
-      - name: Notify on test results
-        run: |
-          if [ "${{ needs.python-unit-tests.result }}" == "success" ]; then
-            echo "success notifications go here"
-          else
-            echo "failure notifications go here"
-          fi
+      - name: Send email on failure
+        if: needs.python-unit-tests.result == 'failure'
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "❌ Python Unit Tests FAILED - ${{ github.repository }}"
+          to: ${{ secrets.EMAIL_USERNAME }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            The Python Unit Tests workflow has failed.
+
+            Repository: ${{ github.repository }}
+            Branch: ${{ github.ref_name }}
+            Commit: ${{ github.sha }}
+            Triggered by: ${{ github.actor }}
+
+            View the failed run here:
+            ${{ github.server_url }}/${{ github.repository }}/actions/run/${{ github.run_id }}
+
+

--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -75,7 +75,7 @@ jobs:
         if: needs.python-unit-tests.result == 'failure'
         uses: dawidd6/action-send-mail@v3
         with:
-          server_address: smtp.gmail.com
+          server_address: send.one.com
           server_port: 465
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}


### PR DESCRIPTION
# Pull Request Template

## Type of Change

## Summary
Modified testsPython.yml to send an email notification 
when the Python Unit Tests job fails.

## Changes
- Added email notification step to the notifications job
- Uses dawidd6/action-send-mail action with Gmail SMTP

- [X ] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

