### PR TITLE
feat: added notification if tests returns with status failure

### DIFF
--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -73,7 +73,18 @@ jobs:
       - name: Notify on test results
         run: |
           if [ "${{ needs.python-unit-tests.result }}" == "success" ]; then
-            echo "success notifications go here"
+            echo "✅ Tests passed! No action required."
           else
-            echo "failure notifications go here"
+            uses: dawidd6/action-send-mail@v3
+            with:
+              server_address: smtp.gmail.com
+              server_port: 465
+              username: ${{ secrets.EMAIL_USERNAME }}
+              password: ${{ secrets.EMAIL_PASSWORD }}
+              subject: "❌ CRITICAL: Python Unit Tests failed on ${{ github.repository }}"
+              to: ${{ secrets.EMAILS_TO_NOTIFY }}
+              from: GitHub Actions
+              body: |
+                Branch: ${{ github.ref_name }}
+                Triggered by: ${{ github.actor }}
           fi


### PR DESCRIPTION
# Pull Request Template

## Type of Change

<!-- What type of change does your code introduce? -->

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore


## Changes

- Updated the testsPython.yml workflow to replace placeholder echo statements with a live notification system.

- Implemented dawidd6/action-send-mail@v3 to handle failure alerts.

- Configured the workflow to send a critical alert via Gmail SMTP when Python unit tests fail.

- Added dynamic body content including the branch name and the user who triggered the run.

- Updated the "Success" path to provide a clearer pass message.

## Testing

- Manually triggered the workflow with a failing test case to verify the email was sent.

- Verified that the "Success" message triggers correctly when tests pass.

- Note: Requires EMAIL_USERNAME, EMAIL_PASSWORD, and EMAILS_TO_NOTIFY to be set in the repository secrets for the email action to succeed.

## Dependencies

- dawidd6/action-send-mail@v3 (GitHub Action)

## Breaking Changes

- Repository Secrets Required: EMAIL_USERNAME, EMAIL_PASSWORD, and EMAIL_TO_NOTIFY