### PR TITLE
Add failure notification to Python Unit Tests workflow

### DIFF
--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -62,18 +62,21 @@ jobs:
           mysql-charset: "${{ secrets.MYSQL_CHARSET }}"
           codecov-token: "${{ secrets.CODECOV_TOKEN }}"
 
-  # Job #2: Notifications (Mini-capstone assignment)
+   # Job #2: Notifications (Mini-capstone assignment)
   # This job will run after the Python unit tests and
-  # is scaffolded to facilitate sending notifications based
-  # on the test results.
+  # sends a notification message when the Python unit test job fails.
   notifications:
     needs: python-unit-tests
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Notify on test results
+      - name: Notify on failed Python unit tests
+        if: ${{ needs.python-unit-tests.result == 'failure' }}
         run: |
-          if [ "${{ needs.python-unit-tests.result }}" == "success" ]; then
-            echo "success notifications go here"
-          else
-            echo "failure notifications go here"
-          fi
+          echo "## Python Unit Test Failure Notification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The Python unit test job failed." >> $GITHUB_STEP_SUMMARY
+          echo "Repository: ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+          echo "Branch: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## Changes
This PR adds a failure notification to the Python Unit Tests GitHub Actions workflow.

A notifications job was implemented to run after the python-unit-tests job using `needs`, with `if: ${{ always() }}` to ensure execution regardless of outcome. A conditional check on `needs.python-unit-tests.result` triggers a notification when tests do not succeed.

The notification writes a structured message to the workflow summary including repository, branch, commit, and workflow run details.

## Testing
- Triggered workflow manually using workflow_dispatch
- Verified notification job runs after test execution
- Confirmed notification appears in workflow summary when tests fail

## Breaking Changes
None