### PR TITLE
Add failure notification to Python unit tests workflow

### DIFF
--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -73,7 +73,12 @@ jobs:
       - name: Notify on test results
         run: |
           if [ "${{ needs.python-unit-tests.result }}" == "success" ]; then
-            echo "success notifications go here"
+            echo "✅ Python unit tests passed successfully!"
           else
-            echo "failure notifications go here"
+            echo "❌ Python unit tests failed! Check the logs for details."
+            exit 1
           fi
+
+      - name: Notify on failure
+        if: failure()
+        run: echo "🚨 Job failed - sending failure notification"

--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -69,6 +69,7 @@ jobs:
   notifications:
     needs: python-unit-tests
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - name: Notify on test results
         run: |


### PR DESCRIPTION
This PR adds a failure notification step to the testsPython.yml 
workflow that alerts when Python unit tests fail.