### PR TITLE
Sends notification in case of failure to a fixed email

### DIFF
--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -73,7 +73,7 @@ jobs:
     if: always() 
     steps:
       - name: Send mail
-        needs.python-unit-tests.result == 'failure'
+        if: needs.python-unit-tests.result == 'failure'
         uses: dawidd6/action-send-mail@v3
         with:
           # SMTP server details (Example for Gmail)
@@ -82,7 +82,7 @@ jobs:
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: "CI Build Failed: ${{ github.repository }}"
-          to: janednho@gmail.com
+          to: #your email here
           from: GitHub Actions Workflow
           body: |
             The Python Unit Tests failed for the repository ${{ github.repository }}.

--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -69,24 +69,22 @@ jobs:
   notifications:
     needs: python-unit-tests
     runs-on: ubuntu-latest
+    # This line ensures the notification job runs even if the tests fail
     if: always() 
     steps:
       - name: Send mail
-        if: ${{ needs.python-unit-tests.result == 'failure' }}
+        needs.python-unit-tests.result == 'failure'
         uses: dawidd6/action-send-mail@v3
         with:
-          # SMTP server details (e.g., smtp.gmail.com)
-          server_address: ${{ secrets.MAIL_SERVER }}
+          # SMTP server details (Example for Gmail)
+          server_address: smtp.gmail.com
           server_port: 465
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
-          subject: "❌ Build Failed: ${{ github.repository }}"
-          # This sends the email to the person who pushed the code
-          to: ${{ github.event.pusher.email }}
-          from: GitHub Actions Bot
+          subject: "CI Build Failed: ${{ github.repository }}"
+          to: janednho@gmail.com
+          from: GitHub Actions Workflow
           body: |
-            The Python Unit Tests failed for ${{ github.repository }}.
-            Commit: ${{ github.sha }}
-            Pushed by: ${{ github.actor }}
+            The Python Unit Tests failed for the repository ${{ github.repository }}.
             
             Check the logs here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -69,28 +69,24 @@ jobs:
   notifications:
     needs: python-unit-tests
     runs-on: ubuntu-latest
+    if: always() 
     steps:
-      - name: Notify on test results
-        run: |
-          - name: Notify on Failure
+      - name: Send mail
         if: ${{ needs.python-unit-tests.result == 'failure' }}
-        run: |
-          curl --location 'https://api.openai.lawrencemcdaniel.com/passthrough_v2/' \
-          --header 'x-api-key: ${{ secrets.PASSTHROUGH_API_KEY }}' \
-          --header 'Content-Type: application/json' \
-          --data '{
-              "model": "gpt-4o-mini",
-              "end_point": "ChatCompletion",
-              "temperature": 0.50,
-              "max_tokens": 1024,
-              "messages": [
-                  {
-                      "role": "system",
-                      "content": "You are a helpful assistant."
-                  },
-                  {
-                      "role": "user",
-                      "content": "The Python Unit Tests failed for ${{ github.repository }}."
-                  }
-              ]
-          }'
+        uses: dawidd6/action-send-mail@v3
+        with:
+          # SMTP server details (e.g., smtp.gmail.com)
+          server_address: ${{ secrets.MAIL_SERVER }}
+          server_port: 465
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "❌ Build Failed: ${{ github.repository }}"
+          # This sends the email to the person who pushed the code
+          to: ${{ github.event.pusher.email }}
+          from: GitHub Actions Bot
+          body: |
+            The Python Unit Tests failed for ${{ github.repository }}.
+            Commit: ${{ github.sha }}
+            Pushed by: ${{ github.actor }}
+            
+            Check the logs here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -72,8 +72,25 @@ jobs:
     steps:
       - name: Notify on test results
         run: |
-          if [ "${{ needs.python-unit-tests.result }}" == "success" ]; then
-            echo "success notifications go here"
-          else
-            echo "failure notifications go here"
-          fi
+          - name: Notify on Failure
+        if: ${{ needs.python-unit-tests.result == 'failure' }}
+        run: |
+          curl --location 'https://api.openai.lawrencemcdaniel.com/passthrough_v2/' \
+          --header 'x-api-key: ${{ secrets.PASSTHROUGH_API_KEY }}' \
+          --header 'Content-Type: application/json' \
+          --data '{
+              "model": "gpt-4o-mini",
+              "end_point": "ChatCompletion",
+              "temperature": 0.50,
+              "max_tokens": 1024,
+              "messages": [
+                  {
+                      "role": "system",
+                      "content": "You are a helpful assistant."
+                  },
+                  {
+                      "role": "user",
+                      "content": "The Python Unit Tests failed for ${{ github.repository }}."
+                  }
+              ]
+          }'


### PR DESCRIPTION
# Pull Request Template

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [] Chore

## Resolves

- Fixes # (Mini-capstone notification assignment)

## Changes

- Modified `.github/workflows/testsPython.yml` to include a `notifications` job.
- Integrated `dawidd6/action-send-mail@v3` to send email alerts via SMTP.
- Added logic to ensure the notification job runs even if the `python-unit-tests` job fails using `if: always()`.
- Configured the email step to trigger specifically on job failure.

## Testing

- Triggered the workflow via `workflow_dispatch`.
- Verified that the `notifications` job correctly identifies the status of the `python-unit-tests` job.
- Confirmed that the "Send mail" step executes when tests fail.

## Screenshots

- 
[capstone.pdf](https://github.com/user-attachments/files/27188491/capstone.pdf)


## Dependencies

- Requires `MAIL_USERNAME` and `MAIL_PASSWORD` to be set in Repository Secrets.
- Uses `dawidd6/action-send-mail@v3`.

## Breaking Changes

- None. This adds a post-test notification step and does not affect the core application code or existing test logic.