### PR TITLE
Notify on Python unit test failure via GitHub Issue

### DIFF
--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -22,6 +22,11 @@ name: Python Unit Tests
 
 on:
   workflow_dispatch: # Allows the workflow to be manually triggered from the GitHub Actions tab
+    inputs:
+      notify_user:
+        description: "GitHub username to @mention on failure (defaults to repo owner)"
+        required: false
+        default: ""
   pull_request: #
     paths: # Trigger workflow on pull requests, but
       - "**.py" # only if Python files are changed
@@ -63,17 +68,27 @@ jobs:
           codecov-token: "${{ secrets.CODECOV_TOKEN }}"
 
   # Job #2: Notifications (Mini-capstone assignment)
-  # This job will run after the Python unit tests and
-  # is scaffolded to facilitate sending notifications based
-  # on the test results.
   notifications:
     needs: python-unit-tests
     runs-on: ubuntu-latest
+    if: always() # ensure this job runs even when python-unit-tests fails
+    permissions:
+      issues: write
     steps:
-      - name: Notify on test results
-        run: |
-          if [ "${{ needs.python-unit-tests.result }}" == "success" ]; then
-            echo "success notifications go here"
-          else
-            echo "failure notifications go here"
-          fi
+      - name: Notify on test failure
+        if: needs.python-unit-tests.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const addressee = '${{ github.event.inputs.notify_user }}' || context.repo.owner;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Python Unit Tests failed on ${context.ref}`,
+              body: `@${addressee} — the Python Unit Tests workflow just failed.\n\n**Run:** ${runUrl}\n**Commit:** \`${context.sha}\`\n**Triggered by:** @${context.actor}`,
+              labels: ['ci-failure']
+            });
+      - name: Log success
+        if: needs.python-unit-tests.result == 'success'
+        run: echo "Python unit tests passed."


### PR DESCRIPTION
Fills in the pre-scaffolded `notifications` job so it actually fires when `python-unit-tests` fails. On failure, opens a GitHub Issue and `@`-mentions me — GitHub auto-emails on mention, so no SMTP or external secrets needed.
