### PR TITLE
Feat: Added Notifications section to notify on failed python test bui…

### DIFF
--- a/.github/workflows/testsPython.yml
+++ b/.github/workflows/testsPython.yml
@@ -66,14 +66,38 @@ jobs:
   # This job will run after the Python unit tests and
   # is scaffolded to facilitate sending notifications based
   # on the test results.
+  # on the test results.
   notifications:
     needs: python-unit-tests
     runs-on: ubuntu-latest
+    if: always() # Ensure this job runs regardless of the previous job's outcome
     steps:
-      - name: Notify on test results
-        run: |
-          if [ "${{ needs.python-unit-tests.result }}" == "success" ]; then
-            echo "success notifications go here"
-          else
-            echo "failure notifications go here"
-          fi
+      - name: Python tests are passed
+        if: ${{ needs.python-unit-tests.result == 'success' }}
+        run: echo "Python unit tests are passed for build ${{ github.run_id }}. No notification needed."
+
+      - name: Python tests are failed
+        if: ${{ needs.python-unit-tests.result == 'failure' }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.NOTIFY_EMAIL }}
+          from: GitHub Actions <${{ secrets.MAIL_USERNAME }}>
+          subject: "Python Unit Tests Failed — ${{ github.repository }}"
+          body: |
+            The Python unit test job failed in ${{ github.repository }}.
+
+            ─────────────────────────────────
+            Repository : ${{ github.repository }}
+            Branch     : ${{ github.ref_name }}
+            Triggered  : ${{ github.actor }}
+            Event      : ${{ github.event_name }}
+            Commit     : ${{ github.sha }}
+            ─────────────────────────────────
+
+            View the failed run:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
This PR is a group submission by Hemant Rathore, Manal Ghanem and Boris Gunn.

[X] New feature

## Changes

Added a new notification section in testPython.yaml file that sends out an email notifications to addressees when there are failures with the test builds.

## Testing

After changes are pushed to my main branch, triggered python test workflow job. It sends out a failure email to addresses configured, also in case of no failures, it does not send out any notifications.

## Screenshots

<img width="1230" height="614" alt="FailureNotification" src="https://github.com/user-attachments/assets/c4f25ed7-4793-4086-942a-bead96a5fe53" />

## Dependencies

This change requires three environment variables to be setup in github "Secrets" section. The three variables are as below

secrets.MAIL_USERNAME = "Your email account user name (possibly gmail)"
secrets.MAIL_PASSWORD = "Your email account password"
secrets.NOTIFY_EMAIL = "List of addressees to notify in comma separated list."

## Breaking Changes
None
